### PR TITLE
[ver_2.1] wrk 파라미터에 스크립트 파일명 입력으로 받음

### DIFF
--- a/src/version2/main.c
+++ b/src/version2/main.c
@@ -13,7 +13,7 @@ int main()
 
     // host, port를 url로 변환
     char url[256];
-    sprintf(url, "https://%s:%d", target_host, target_port);
+    sprintf(url, "http://%s:%d", target_host, target_port);
 
     // return run_client(target_port, target_host);
     return run_wrk(url);

--- a/src/version2/wrk/wrk_script/sample.lua
+++ b/src/version2/wrk/wrk_script/sample.lua
@@ -1,0 +1,22 @@
+-- 랜덤한 docName 생성 함수
+function random_docname()
+    local docnames = {
+        "home", "about", "contact", "services", "products",
+        "blog", "faq", "terms", "privacy", "help"
+    }
+    return docnames[math.random(1, #docnames)]
+end
+
+-- HTTP 요청 메시지를 작성하는 함수
+function request()
+    local docName = random_docname() -- 랜덤하게 docName을 선택
+
+    local request_message = string.format(
+        "GET /?docName=%s HTTP/1.1\r\n" ..
+        "Host: %s\r\n" ..
+        "\r\n",
+        docName, wrk.host  -- wrk.host는 wrk 실행 시에 설정된 호스트값을 자동으로 사용
+    )
+
+    return wrk.format("GET", "/", nil, request_message)  -- GET 요청 반환
+end


### PR DESCRIPTION
## 연관된 이슈 #️⃣

#9 

## 작업 내용 📝

`main.c`에서 url `http://~`로 수정.

입력으로 스크립트 파일명을 받도록 `wrk.c` 수정.
`example.lua`와 같이 입력. `wrk/wrk_script`에 존재하지 않는 파일명일 경우 에러 처리.

<br>

`sample.lua`는 다음과 같음
```
-- 랜덤한 docName 생성 함수
function random_docname()
    local docnames = {
        "home", "about", "contact", "services", "products",
        "blog", "faq", "terms", "privacy", "help"
    }
    return docnames[math.random(1, #docnames)]
end

-- HTTP 요청 메시지를 작성하는 함수
function request()
    local docName = random_docname() -- 랜덤하게 docName을 선택

    local request_message = string.format(
        "GET /?docName=%s HTTP/1.1\r\n" ..
        "Host: %s\r\n" ..
        "\r\n",
        docName, wrk.host  -- wrk.host는 wrk 실행 시에 설정된 호스트값을 자동으로 사용
    )

    return wrk.format("GET", "/", nil, request_message)  -- GET 요청 반환
end
```

### 스크린샷 (선택)
